### PR TITLE
Exposed siteModeSupported() as public method $.pinify.siteModeSupported()

### DIFF
--- a/js/jquery.pinify.js
+++ b/js/jquery.pinify.js
@@ -296,6 +296,7 @@
           return window.external.msIsSiteModeFirstRun(preserveState);
         }, 0);
       },
+      siteModeSupported: siteModeSupported
       isPinned: function() {
         if (!siteModeSupported()) {
           return false;


### PR DESCRIPTION
Because e.g. sometimes other code should only be run if pinning is supported (e.g. polling the server for updates for the jump list)
